### PR TITLE
Removal and replacement of flag.Func for version compat

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ sudo apt-get -y install golang
 sudo apt-get -y install git
 ```
 
-`dbbench` requires golang version >= 1.10. Check the golang version:
+`dbbench` requires golang version >= 1.13. Check the golang version:
 
 ```console
 go version

--- a/dbbench.go
+++ b/dbbench.go
@@ -84,6 +84,33 @@ var printVersion = flag.Bool("version", false, "Print the version and quit")
 
 var GlobalConfig ConnectionConfig
 
+type URLString struct {
+	URL *url.URL
+}
+
+func (v URLString) String() string {
+	if v.URL != nil {
+		return v.URL.String()
+	}
+	return ""
+}
+
+func (v URLString) Set(s string) error {
+	if s == "" {
+		return errors.New("empty connection URL")
+	} else if u, err := url.Parse(s); err != nil {
+		return err
+	} else {
+		GlobalConfig.OverrideFromURL(*u)
+		if u.Scheme != "" {
+			*driverName = u.Scheme
+		}
+	}
+	return nil
+}
+
+var u = &url.URL{}
+
 func init() {
 	flag.StringVar(&GlobalConfig.Username, "username", "",
 		"Database connection username")
@@ -97,19 +124,7 @@ func init() {
 		"Database connection database")
 	flag.StringVar(&GlobalConfig.Params, "params", "",
 		"Override default connection parameters")
-	flag.Func("url", "Connection url (mysql://user:pass@host:port?params), parameters provided here override those provided by other options", func(s string) error {
-		if s == "" {
-			return errors.New("empty connection URL")
-		} else if u, err := url.Parse(s); err != nil {
-			return err
-		} else {
-			GlobalConfig.OverrideFromURL(*u)
-			if u.Scheme != "" {
-				*driverName = u.Scheme
-			}
-		}
-		return nil
-	})
+	flag.Var(URLString{u}, "url", "Connection url (mysql://user:pass@host:port?params), parameters provided here override those provided by other options")
 }
 
 func main() {


### PR DESCRIPTION
Filed an issue about this. Basically, because we were using flag.Func we could not build dbbench on Go < 1.16 (as flag.Func was added in 1.16)

This was a quick fix-up (will likely need a review) that I was able to do some testing on 1.10 and 1.13. It appears it works fine on 1.13, but I'm getting a separate error for 1.10:

```
# github.com/vertica/vertica-sql-go
Go/src/github.com/vertica/vertica-sql-go/rows.go:328:25: undefined: sql.NullTime
# github.com/go-sql-driver/mysql
Go/src/github.com/go-sql-driver/mysql/nulltime.go:36:15: undefined: sql.NullTime
```

So with this PR, we can support Go versions 1.13+ (which includes the current 1.14 Go version on LTS Ubuntu for example) from my testing. May be able to get around the above error with some more research.

Would be smart to have someone else test this as well as I put it together pretty quickly. I ran it against a cluster (using the --url parameter which is the bulk of the changes here) and it performed as expected.